### PR TITLE
Remove macOS specific files before replacing template files

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -29,6 +29,8 @@ then
   usage
 fi  
 
+rm templates/.DS_Store  # avoid “Illegal byte sequence” error
+
 echo "Replacing variables in template files..."
 echo "$\{instanceName\}: ${INSTANCE_NAME}"
 echo "$\{instanceMaintainer\}: ${INSTANCE_MAINTAINER}"


### PR DESCRIPTION
Prevents `sed` error `Illegal byte sequence` as it tries to replace the contents of `.DS_Store`.