### PR TITLE
Bump engine to v0.30

### DIFF
--- a/templates/package.json
+++ b/templates/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "lint": "ota lint",
     "lint:fix": "ota lint -- --fix",
-    "test": "ota validate",
-    "test:schema": "npm run test -- --schema-only",
-    "test:modified": "npm run test -- --modified",
+    "test": "ota lint && ota validate",
+    "test:schema": "ota validate --schema-only",
+    "test:modified": "ota validate --modified",
     "start": "ota track",
     "start:schedule": "npm run start -- --schedule",
     "start:modified": "git diff --name-only HEAD $(git merge-base HEAD origin/main) -- ./declarations/ | grep -v .history | grep -v .filters | sed 's/declarations\\///g' | sed 's/.json//g' | sed 's/.*/\"&\"/' | xargs -r npm run start -- --services",
@@ -14,6 +14,6 @@
     "dataset:schedule": "npm run dataset -- --publish --remove-local-copy --schedule"
   },
   "dependencies": {
-    "@opentermsarchive/engine": "~0.25.0"
+    "@opentermsarchive/engine": "~0.30.0"
   }
 }


### PR DESCRIPTION
Update linting and validation scripts, see https://github.com/OpenTermsArchive/demo-declarations/pull/8.